### PR TITLE
Add student behavior classes (Glock, Sullivan) and adjust printer margins

### DIFF
--- a/public/cards/student-behavior-classes.yaml
+++ b/public/cards/student-behavior-classes.yaml
@@ -1,0 +1,34 @@
+glock:
+- Talking out of turn
+- Verbal aggression
+- Physical aggression
+- Destruction
+- Using a mobile phone
+- Calling out
+- Getting out of seat
+- Swinging the chair
+- Snapping fingers
+- Inattentiveness
+- Whispering
+- Drawing a picture
+- Rustling paper
+- Lack of interest
+
+sullivan:
+- Talking out of turn
+- Avoiding doing schoolwork
+- Disengaging from classroom activities
+- Being late for class
+- Disrupting the flow of a lesson
+- Moving around the room unnecessarily
+- Making distracting noises intentionally
+- Mucking around, being rowdy
+- Making impertinent remarks
+- Interfering with property
+- Verbally abusing other students
+- Using a mobile phone inappropriately
+- Excluding peers
+- Spreading rumours
+- Physically aggressive towards other students
+- Displaying uncharacteristically erratic behaviours
+- Using a laptop or iPad inappropriately

--- a/src/App.css
+++ b/src/App.css
@@ -21,8 +21,8 @@
 }
 
 .printable {
-  margin-left: 0.21in;
-  margin-right: 0.21in;
+  margin-left: 0.1in;
+  margin-right: 0.1in;
 }
 
 @media print {

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,8 @@ const files = [
   '/cards/committee-of-n.yaml',
   '/cards/bias-boggle.yaml',
   '/cards/bias-behaviors.yaml',
-  '/cards/strs.yaml'
+  '/cards/strs.yaml',
+  '/cards/student-behavior-classes.yaml'
 ];
 class App extends Component {
   constructor() {


### PR DESCRIPTION
Sourced from:
- Stop talking out of turn: The influence of students' gender and ethnicity on preservice teachers' intervention strategies for student misbehavior ([Glock 2016](http://www.sciencedirect.com/science/article/pii/S0742051X16300385))
- Punish Them or Engage Them? Teachers’ Views of Unproductive Student Behaviours in the Classroom ([Sullivan et al. 2014](http://ro.ecu.edu.au/cgi/viewcontent.cgi?article=2356&context=ajte)).